### PR TITLE
Polyfill non-modal dialogs

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,16 @@ function documentEscapeHandler(event) {
       break;
     }
     if (closedBy === "any" || closedBy === "closerequest") {
+      if (!dialog.matches(":modal")) {
+        const cancelEvent = new Event("cancel", {
+          bubbles: false,
+          cancelable: true
+        });
+        if (!dialog.dispatchEvent(cancelEvent)) {
+          shouldPreventDefault = true;
+          break;
+        }
+      }
       dialog.close();
       hasClosableDialog = true;
       break;
@@ -39,7 +49,18 @@ function createLightDismissHandler(dialog) {
     const rect = dialog.getBoundingClientRect();
     const { clientX: x, clientY: y } = event;
     const inside = rect.top <= y && y <= rect.bottom && rect.left <= x && x <= rect.right;
-    if (!inside) dialog.close();
+    if (!inside) {
+      if (!dialog.matches(":modal")) {
+        const cancelEvent = new Event("cancel", {
+          bubbles: false,
+          cancelable: true
+        });
+        if (!dialog.dispatchEvent(cancelEvent)) {
+          return;
+        }
+      }
+      dialog.close();
+    }
   };
 }
 function createClickHandler(dialog) {
@@ -48,7 +69,18 @@ function createClickHandler(dialog) {
     if (getClosedByValue(dialog) !== "any") return;
     const rect = dialog.getBoundingClientRect();
     const inside = rect.top < event.clientY && event.clientY < rect.bottom && rect.left < event.clientX && event.clientX < rect.right;
-    if (!inside) dialog.close();
+    if (!inside) {
+      if (!dialog.matches(":modal")) {
+        const cancelEvent = new Event("cancel", {
+          bubbles: false,
+          cancelable: true
+        });
+        if (!dialog.dispatchEvent(cancelEvent)) {
+          return;
+        }
+      }
+      dialog.close();
+    }
   };
 }
 function createCancelHandler(dialog) {
@@ -149,13 +181,20 @@ function apply() {
     );
     return;
   }
+  const originalShow = HTMLDialogElement.prototype.show;
   const originalShowModal = HTMLDialogElement.prototype.showModal;
   const originalClose = HTMLDialogElement.prototype.close;
-  HTMLDialogElement.prototype.showModal = function showModalPatched() {
-    originalShowModal.call(this);
-    if (!this.open) return;
-    if (this.hasAttribute("closedby")) attachDialog(this);
-  };
+  function wrapDialogMethod(originalMethod) {
+    return function() {
+      originalMethod.call(this);
+      if (!this.open) return;
+      if (this.hasAttribute("closedby")) {
+        attachDialog(this);
+      }
+    };
+  }
+  HTMLDialogElement.prototype.show = wrapDialogMethod(originalShow);
+  HTMLDialogElement.prototype.showModal = wrapDialogMethod(originalShowModal);
   HTMLDialogElement.prototype.close = function closePatched(returnValue) {
     detachDialog(this);
     originalClose.call(this, returnValue);

--- a/index.js
+++ b/index.js
@@ -21,15 +21,13 @@ function documentEscapeHandler(event) {
       break;
     }
     if (closedBy === "any" || closedBy === "closerequest") {
-      if (!dialog.matches(":modal")) {
-        const cancelEvent = new Event("cancel", {
-          bubbles: false,
-          cancelable: true
-        });
-        if (!dialog.dispatchEvent(cancelEvent)) {
-          shouldPreventDefault = true;
-          break;
-        }
+      const cancelEvent = new Event("cancel", {
+        bubbles: false,
+        cancelable: true
+      });
+      if (!dialog.dispatchEvent(cancelEvent)) {
+        shouldPreventDefault = true;
+        break;
       }
       dialog.close();
       hasClosableDialog = true;
@@ -50,14 +48,12 @@ function createLightDismissHandler(dialog) {
     const { clientX: x, clientY: y } = event;
     const inside = rect.top <= y && y <= rect.bottom && rect.left <= x && x <= rect.right;
     if (!inside) {
-      if (!dialog.matches(":modal")) {
-        const cancelEvent = new Event("cancel", {
-          bubbles: false,
-          cancelable: true
-        });
-        if (!dialog.dispatchEvent(cancelEvent)) {
-          return;
-        }
+      const cancelEvent = new Event("cancel", {
+        bubbles: false,
+        cancelable: true
+      });
+      if (!dialog.dispatchEvent(cancelEvent)) {
+        return;
       }
       dialog.close();
     }
@@ -70,14 +66,12 @@ function createClickHandler(dialog) {
     const rect = dialog.getBoundingClientRect();
     const inside = rect.top < event.clientY && event.clientY < rect.bottom && rect.left < event.clientX && event.clientX < rect.right;
     if (!inside) {
-      if (!dialog.matches(":modal")) {
-        const cancelEvent = new Event("cancel", {
-          bubbles: false,
-          cancelable: true
-        });
-        if (!dialog.dispatchEvent(cancelEvent)) {
-          return;
-        }
+      const cancelEvent = new Event("cancel", {
+        bubbles: false,
+        cancelable: true
+      });
+      if (!dialog.dispatchEvent(cancelEvent)) {
+        return;
       }
       dialog.close();
     }

--- a/src/listeners.ts
+++ b/src/listeners.ts
@@ -79,17 +79,15 @@ function documentEscapeHandler(event: KeyboardEvent): void {
 
     if (closedBy === "any" || closedBy === "closerequest") {
       // For non-modal dialogs, dispatch cancel event before closing
-      if (!dialog.matches(':modal')) {
-        const cancelEvent = new Event("cancel", {
-          bubbles: false,
-          cancelable: true,
-        });
-        
-        if (!dialog.dispatchEvent(cancelEvent)) {
-          // cancel was prevented, treat as if closedBy="none"
-          shouldPreventDefault = true;
-          break;
-        }
+      const cancelEvent = new Event("cancel", {
+        bubbles: false,
+        cancelable: true,
+      });
+
+      if (!dialog.dispatchEvent(cancelEvent)) {
+        // cancel was prevented, treat as if closedBy="none"
+        shouldPreventDefault = true;
+        break;
       }
 
       // Close only the topmost closable dialog and stop processing
@@ -140,17 +138,16 @@ function createLightDismissHandler(dialog: HTMLDialogElement) {
 
     if (!inside) {
       // For non-modal dialogs, dispatch cancel event before closing
-      if (!dialog.matches(':modal')) {
-        const cancelEvent = new Event("cancel", {
-          bubbles: false,
-          cancelable: true,
-        });
+      const cancelEvent = new Event("cancel", {
+        bubbles: false,
+        cancelable: true,
+      });
 
-        if (!dialog.dispatchEvent(cancelEvent)) {
-          // cancel was prevented, don't close
-          return;
-        }
+      if (!dialog.dispatchEvent(cancelEvent)) {
+        // cancel was prevented, don't close
+        return;
       }
+
       dialog.close();
     }
   };
@@ -180,17 +177,16 @@ function createClickHandler(dialog: HTMLDialogElement) {
 
     if (!inside) {
       // For non-modal dialogs, dispatch cancel event before closing
-      if (!dialog.matches(':modal')) {
-        const cancelEvent = new Event("cancel", {
-          bubbles: false,
-          cancelable: true,
-        });
+      const cancelEvent = new Event("cancel", {
+        bubbles: false,
+        cancelable: true,
+      });
 
-        if (!dialog.dispatchEvent(cancelEvent)) {
-          // cancel was prevented, don't close
-          return;
-        }
+      if (!dialog.dispatchEvent(cancelEvent)) {
+        // cancel was prevented, don't close
+        return;
       }
+
       dialog.close();
     }
   };

--- a/src/listeners.ts
+++ b/src/listeners.ts
@@ -78,6 +78,20 @@ function documentEscapeHandler(event: KeyboardEvent): void {
     }
 
     if (closedBy === "any" || closedBy === "closerequest") {
+      // For non-modal dialogs, dispatch cancel event before closing
+      if (!dialog.matches(':modal')) {
+        const cancelEvent = new Event("cancel", {
+          bubbles: false,
+          cancelable: true,
+        });
+        
+        if (!dialog.dispatchEvent(cancelEvent)) {
+          // cancel was prevented, treat as if closedBy="none"
+          shouldPreventDefault = true;
+          break;
+        }
+      }
+
       // Close only the topmost closable dialog and stop processing
       dialog.close();
       hasClosableDialog = true;
@@ -124,7 +138,21 @@ function createLightDismissHandler(dialog: HTMLDialogElement) {
     const inside =
       rect.top <= y && y <= rect.bottom && rect.left <= x && x <= rect.right;
 
-    if (!inside) dialog.close();
+    if (!inside) {
+      // For non-modal dialogs, dispatch cancel event before closing
+      if (!dialog.matches(':modal')) {
+        const cancelEvent = new Event("cancel", {
+          bubbles: false,
+          cancelable: true,
+        });
+
+        if (!dialog.dispatchEvent(cancelEvent)) {
+          // cancel was prevented, don't close
+          return;
+        }
+      }
+      dialog.close();
+    }
   };
 }
 
@@ -150,7 +178,21 @@ function createClickHandler(dialog: HTMLDialogElement) {
       rect.left < event.clientX &&
       event.clientX < rect.right;
 
-    if (!inside) dialog.close();
+    if (!inside) {
+      // For non-modal dialogs, dispatch cancel event before closing
+      if (!dialog.matches(':modal')) {
+        const cancelEvent = new Event("cancel", {
+          bubbles: false,
+          cancelable: true,
+        });
+
+        if (!dialog.dispatchEvent(cancelEvent)) {
+          // cancel was prevented, don't close
+          return;
+        }
+      }
+      dialog.close();
+    }
   };
 }
 


### PR DESCRIPTION
Hello,

This PR adds support for closedby on non-modal dialog (dialog open with `show` instead of `showModal`). As per spec and Chrome implementation, the closedby is also honored for them.

This PR adds two things:

* It also monkey patches the `show` method.
* It dispatches the `cancel` event on all dialog (modal and non-modal) which is triggered by Chrome, to allow to prevent the close.

With those two changes it should now be very close to the complete spec.

Thanks!