### PR TITLE
Fix cancel on backdrop click

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,10 @@ function createLightDismissHandler(dialog) {
       return;
     }
     if (!isClickInsideDialog(dialog, event.clientX, event.clientY)) {
-      dialog.close();
+      const notCancelled = dialog.dispatchEvent(new Event("cancel", { bubbles: false, cancelable: true }));
+      if (notCancelled) {
+        dialog.close();
+      }
     }
   };
 }

--- a/src/listeners.ts
+++ b/src/listeners.ts
@@ -172,7 +172,11 @@ function createLightDismissHandler(dialog: HTMLDialogElement) {
     }
 
     if (!isClickInsideDialog(dialog, event.clientX, event.clientY)) {
-      dialog.close();
+      const notCancelled = dialog.dispatchEvent(new Event('cancel', { bubbles: false, cancelable: true }));
+
+      if (notCancelled) {
+        dialog.close();
+      }
     }
   };
 }


### PR DESCRIPTION
This PR fixes #17 by ensuring that when clicking on the backdrop, the `cancel` event is emitted first, so that developer can eventually cancel it.

This aligns the behavior with Chrome behavior and what the spec is explaining.