### PR TITLE
fix: feature detection and attachDialog on Safari 26.3 

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,14 @@ function observeRoot(root) {
           });
         }
       });
+      mutations.forEach(async (m2) => {
+        if (m2.attributeName === "open") {
+          const node = m2.target;
+          if (node instanceof HTMLDialogElement && node.open && node.hasAttribute("closedby")) {
+            attachDialog(node);
+          }
+        }
+      });
       m.removedNodes.forEach((node) => {
         if (node instanceof HTMLDialogElement) detachDialog(node);
         if (node instanceof Element)
@@ -144,7 +152,7 @@ function observeRoot(root) {
   });
   const observedTarget = root === document ? document.body : root;
   if (observedTarget) {
-    rootObserver.observe(observedTarget, { childList: true, subtree: true });
+    rootObserver.observe(observedTarget, { childList: true, subtree: true, attributes: true, attributeFilter: ["open"] });
     observers.set(root, rootObserver);
   }
 }

--- a/index.js
+++ b/index.js
@@ -206,7 +206,6 @@ function isSupported() {
   }
   try {
     const testDialog = document.createElement("dialog");
-    testDialog.setAttribute("closedby", "none");
     return testDialog.closedBy === "none";
   } catch {
     return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,6 @@ export function isSupported(): boolean {
   // getter does not return the expected value.
   try {
     const testDialog = document.createElement("dialog");
-    testDialog.setAttribute("closedby", "none");
     return (testDialog as HTMLDialogElement & { closedBy?: string }).closedBy === "none";
   } catch {
     // If anything goes wrong during the behavioural check, treat the

--- a/src/observer.ts
+++ b/src/observer.ts
@@ -41,6 +41,20 @@ export function observeRoot(root: Document | ShadowRoot): void {
         }
       });
 
+      /* Handle changed open attribute */
+      mutations.forEach(async m => {
+        if (m.attributeName === 'open') {
+          const node = m.target;
+          if (
+            node instanceof HTMLDialogElement &&
+            node.open &&
+            node.hasAttribute("closedby")
+          ) {
+            attachDialog(node);
+          }
+        }
+      })
+
       /* Handle removed nodes */
       m.removedNodes.forEach((node) => {
         if (node instanceof HTMLDialogElement) detachDialog(node);
@@ -52,7 +66,7 @@ export function observeRoot(root: Document | ShadowRoot): void {
 
   const observedTarget = root === document ? document.body : root;
   if (observedTarget) {
-    rootObserver.observe(observedTarget, { childList: true, subtree: true });
+    rootObserver.observe(observedTarget, { childList: true, subtree: true, attributes: true, attributeFilter: ["open"] });
     observers.set(root, rootObserver);
   }
 }


### PR DESCRIPTION
See https://github.com/tak-dcxi/dialog-closedby-polyfill/issues/15

Safari 26.3 (and 26.3.1) should be detected as not supported.

`attachDialog` is never applied to the first dialog in the example `closedyby.html`. `ESC` works as it is supported by dialog element natively, but clicking on the backdrop don't work.